### PR TITLE
Fix month format (%m) to return [01,12]

### DIFF
--- a/src/DateTimeFormatter.js
+++ b/src/DateTimeFormatter.js
@@ -131,7 +131,8 @@ function dateToString(format, date = new Date()) {
                 output += _get12Hour(date.getHours())
                 break;
             case 'm':
-                output += date.getMonth().toString().padStart(2, '0');
+                let month = date.getMonth() + 1;
+                output += month.toString().padStart(2, '0');
                 break;
             case 'p':
                 output =+ (date.getHours() < 12) ? 'AM' : 'PM';


### PR DESCRIPTION
Date.getMonth() return values between 00 and 11 [1]. Expected value for
month when printed is between 01 and 12 [2].

[1] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth
[2] http://pubs.opengroup.org/onlinepubs/007908799/xsh/strftime.html